### PR TITLE
Fix json parse error when not using json

### DIFF
--- a/cloudflare.js
+++ b/cloudflare.js
@@ -38,7 +38,11 @@ async function get(kvUrl, headers) {
     responseEncoding: 'utf8'
   })
   const text = await response.text()
-  return text
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
 }
 
 export default async function kv(

--- a/cloudflare.js
+++ b/cloudflare.js
@@ -37,9 +37,8 @@ async function get(kvUrl, headers) {
     responseType: 'json',
     responseEncoding: 'utf8'
   })
-  const data = await response.text()
-  const json = JSON.parse(data)
-  return json
+  const text = await response.text()
+  return text
 }
 
 export default async function kv(


### PR DESCRIPTION
Imo this action shouldn't assume the value is json, just return the text and allow the user to parse json if they're expecting it.

Eg I have a key with a value of

```
assets_checksum=605d14e4162af0fca0b26411c5aa2b584504d4b04a168a617777689ec681949b
assets_url=https://cdn.legendsoftaria.com/assets.zip
```

This breaks this action with this error

```
Getting value for config_properties
Error: Unexpected token 'a', "assets_che"... is not valid JSON
```